### PR TITLE
fix GTP Tunnel sequence number issue #186

### DIFF
--- a/src/up/up_path.c
+++ b/src/up/up_path.c
@@ -102,7 +102,7 @@ Status GtpHandleEchoRequest(Sock *sock, void *data) {
     if (gtpRespHrd.flags & 0x03) {
         Gtpv1OptHeader *opthrd = (void *)((uint8_t *) data + GTPV1_HEADER_LEN);
         Gtpv1OptHeader gtpOptHrd = {
-            ._seqNum = (gtpRespHrd.flags & 0x02) ? htons(ntohs(opthrd->_seqNum) + 1) : 0,
+            ._seqNum = (gtpRespHrd.flags & 0x02) ? htons(ntohs(opthrd->_seqNum)) : 0,
             .nPdnNum = (gtpRespHrd.flags & 0x01) ? opthrd->nPdnNum : 0,
         };
         BufblkBytes(optPkt, (void *) &gtpOptHrd, sizeof(gtpOptHrd));


### PR DESCRIPTION
## Describe the bug - GTP Tunnel sequence number issue
According to 3GPP TS 29.281
GTP Tunnel sequence number should be same
"The Sequence Number in a signalling response message shall be copied from the signalling request message that the GTP-U entity is replying to"
![image](https://user-images.githubusercontent.com/26329788/110272881-39094500-8006-11eb-9eee-d0e692b2296d.png)

In your implementation, upf/src/up/up_path.c.  line 105
           ` ._seqNum = (gtpRespHrd.flags & 0x02) ? htons(ntohs(opthrd->_seqNum) + 1) : 0,`

there are something wrong for the seqNum +1

We are tying to attach a 5G SA UE to free5GC UPF (via one of the vendor's RAN & Core), the PDU session will be deleted by SMF, and the reason seems to be incorrect sequence number in GTP_Echo_Response.

after remove +1 for the sequence number, our UE attach is success and with internet access


## Environment (please complete the following information):
 - free5GC Version: 3.0.5
 - OS: Ubuntu 

