### PR TITLE
Fixed the IPv6 argument set in PfcpSockaddrToFSeid is that of IPv4

### DIFF
--- a/src/n4/n4_pfcp_build.c
+++ b/src/n4/n4_pfcp_build.c
@@ -47,7 +47,7 @@ Status UpfN4BuildSessionEstablishmentResponse(Bufblk **bufBlk, uint8_t type,
         response->uPFSEID.value = &fSeid;
         fSeid.seid = htobe64(session->upfSeid);
         status = PfcpSockaddrToFSeid(Self()->pfcpAddr,
-                                     Self()->pfcpAddr, &fSeid, &len);
+                                     Self()->pfcpAddr6, &fSeid, &len);
         response->uPFSEID.len = len;
 
         /* FQ-CSID */


### PR DESCRIPTION
Fixed the IPv6 argument set in PfcpSockaddrToFSeid is that of IPv4