### PR TITLE
Fixed globalXactId after that equal to MAX_XACT_ID

### DIFF
--- a/lib/pfcp/src/pfcp_xact.c
+++ b/lib/pfcp/src/pfcp_xact.c
@@ -79,7 +79,7 @@ PfcpXact *PfcpXactLocalCreate(PfcpNode *gnode, PfcpHeader *header, Bufblk *bufBl
     UTLT_Assert(xact, return NULL, "Transaction allocation failed");
 
     xact->origin = PFCP_LOCAL_ORIGINATOR;
-    xact->transactionId = (globalXactId == PFCP_MAX_XACT_ID ? PFCP_MIN_XACT_ID : ++globalXactId);
+    xact->transactionId = (globalXactId = (globalXactId == PFCP_MAX_XACT_ID ? PFCP_MIN_XACT_ID : ++globalXactId));
 
     xact->gnode = gnode;
     /*TODO: fix this


### PR DESCRIPTION
After globalXactId == PFCP_MAX_XACT_ID, globalXactId should also set to be PFCP_MIN_XACT_ID.
Otherwise, next time PfcpXactLocalCreate be called, globalXactId will over than PFCP_MAX_XACT_ID