### PR TITLE
Fix: UPF send multiple buffered packet by 1 GTP packet when paging

### DIFF
--- a/lib/utlt/include/utlt_buff.h
+++ b/lib/utlt/include/utlt_buff.h
@@ -38,6 +38,7 @@ Status BufblkFmt(Bufblk *bufblk, const char *fmt, ...)
         __attribute__((format(printf, 2, 3)));
 Status BufblkBytes(Bufblk *bufblk, const char *str, uint32_t size);
 Status BufblkAppend(Bufblk *bufblk, uint32_t num, uint32_t size);
+int BufIsNotEnough(Bufblk *bufblk, uint32_t num, uint32_t size);
 
 void *UTLT_Malloc(uint32_t size);
 void *UTLT_Calloc(uint32_t num, uint32_t size);

--- a/lib/utlt/src/utlt_buff.c
+++ b/lib/utlt/src/utlt_buff.c
@@ -66,7 +66,6 @@ Status SelectBufblkOption(Bufblk *bufblk, int opt);
 Status BufAlloc(Bufblk *bufblk, uint32_t num, uint32_t size);
 Status BufFree(Bufblk *bufblk);
 
-int BufIsNotEnough(Bufblk *bufblk, uint32_t num, uint32_t size);
 
 #define BUF_ALLOC 1
 #define BUF_FREE  2

--- a/src/up/up_match.c
+++ b/src/up/up_match.c
@@ -403,7 +403,13 @@ static int PacketInBufferHandle(uint8_t *pkt, uint16_t pktlen, UPDK_PDR *matched
                 "UpfBufPacket alloc failed");
         }
 
+        if (BufIsNotEnough(packetStorage->packetBuffer, 1, sizeof(pktlen) + pktlen)) {
+            UTLT_Level_Assert(LOG_DEBUG, BufblkResize(packetStorage->packetBuffer, 1, packetStorage->packetBuffer->size + sizeof(pktlen) + pktlen) == STATUS_OK,
+            goto unlockErrorReturn, "block add behind old buffer error");
+        }
+
         // if packetBuffer not null, just add packet followed
+        BufblkBytes(packetStorage->packetBuffer, (const char *)&pktlen, sizeof(pktlen));
         status = BufblkBytes(packetStorage->packetBuffer, (const char *) pkt, pktlen);
         UTLT_Level_Assert(LOG_DEBUG, status == STATUS_OK,
             pthread_spin_unlock(&Self()->buffLock); goto unlockErrorReturn,


### PR DESCRIPTION
When buffered data is stored, information of length for each packet is held.
When sending data, the stored contents are taken out by length, added with a header, and transmitted.