### PR TITLE
Fix: Blocking queue can lead to deadlock.

### DIFF
--- a/src/upf_init.c
+++ b/src/upf_init.c
@@ -233,7 +233,7 @@ static Status EpollTerm(void *data) {
 }
 
 static Status EventQueueInit(void *data) {
-    Self()->eventQ = EventQueueCreate(O_RDWR);
+    Self()->eventQ = EventQueueCreate(O_RDWR | O_NONBLOCK);
     UTLT_Assert(Self()->eventQ > 0, return STATUS_ERROR, "");
 
     return STATUS_OK;


### PR DESCRIPTION
Blocking queue can lead to a deadlock. 

When the queue is full, mq_send() is blocked, EventSend() cannot finish its execution, and the mutex is never released.

https://github.com/srac0/upf/blob/1257e6138aba3b61823d3d9372f27e16cf2c15e6/lib/utlt/src/utlt_mq.c#L59

Then, the next requests will not be handled because it is impossible to acquire the mutex.