### PR TITLE
Fix: When a large number of PfcpXacts are timerexpire at approximately the same time, TimerExpireCheck deadlocks and cannot transmit or receive PFCPs.

### DIFF
--- a/lib/test/src/testTimer.c
+++ b/lib/test/src/testTimer.c
@@ -23,10 +23,12 @@ TestTimerEliment timerEliment[] ={
     {TIMER_TYPE_ONCE, 130}
 };
 
-void TestExpireFunc(uintptr_t data, uintptr_t param[]) {
+Status TestExpireFunc(uintptr_t data, uintptr_t param[]) {
     uint32_t index = param[1];
 
     expireCheck[index]++;
+
+    return STATUS_OK;
 }
 
 Status TestTimer_1() {

--- a/lib/utlt/include/utlt_timer.h
+++ b/lib/utlt/include/utlt_timer.h
@@ -33,7 +33,7 @@ typedef struct _TimerList {
 
 typedef uintptr_t TimerBlkID;
 
-typedef void (*ExpireFunc)(uintptr_t data, uintptr_t param[]);
+typedef Status (*ExpireFunc)(uintptr_t data, uintptr_t param[]);
 
 Status TimerPoolInit();
 Status TimerFinal();


### PR DESCRIPTION
- If the timerExpire trigger EventSend() fails, an error occurs and processing continues.
- If the timerExpire trigger EventSend() fails, it is processed after the next cycle.