### PR TITLE
Fix the deadlock between TimerExpireCheck() and PfcpXactDelete()

### DIFF
--- a/lib/pfcp/src/pfcp_xact.c
+++ b/lib/pfcp/src/pfcp_xact.c
@@ -664,7 +664,7 @@ Status PfcpXactTimeout(uint32_t index, uint32_t event, uint8_t *type) {
             PfcpXactDelete(xact);
             return STATUS_ERROR;            
         }
-    } else if (event == globalHoldingEvent) {
+    } else if (event == globalHoldingEvent && TimerIsExpired(xact->timerHolding)) {
         UTLT_Trace("[%d] %s Holding Timeout for step %d type %d peer [%s]:%d\n",
                 xact->transactionId, xact->origin == PFCP_LOCAL_ORIGINATOR ? "local" : "remote",
                 xact->step, xact->seq[xact->step-1].type,

--- a/lib/utlt/include/utlt_timer.h
+++ b/lib/utlt/include/utlt_timer.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <pthread.h>
+#include <stdbool.h>
 
 #include "utlt_debug.h"
 #include "utlt_list.h"
@@ -48,6 +49,7 @@ Status TimerStop(TimerBlkID id);
 TimerBlkID TimerCreate(TimerList *tmList, int type, uint32_t duration, ExpireFunc expireFunc);
 void TimerDelete(TimerBlkID id);
 Status TimerSet(int paramID, TimerBlkID id, uintptr_t param);
+bool TimerIsExpired(TimerBlkID id);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Move TimerBlk::expireFunc call out of the  mutex critical section.
- Add a expiration check of PfcpXact::timerHolding in PfcpXactTimeout().