### PR TITLE
Fixed: UTLT_LogPrint() is not thread safe.

### DIFF
--- a/lib/utlt/include/utlt_debug.h
+++ b/lib/utlt/include/utlt_debug.h
@@ -5,12 +5,15 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#include <pthread.h>
 #include <string.h>
 
 typedef int Status;
 #define STATUS_ERROR -1
 #define STATUS_OK 0
 #define STATUS_EAGAIN 1
+
+extern pthread_mutex_t UTLT_logBufLock;
 
 Status UTLT_SetLogLevel(const char *level);
 Status UTLT_SetReportCaller(unsigned int reportCaller);

--- a/src/upf.c
+++ b/src/upf.c
@@ -15,6 +15,7 @@ static void eventConsumer();
 
 int main(int argc, char *argv[]) {
     Status status, returnStatus = STATUS_OK;
+    pthread_mutex_init(&UTLT_logBufLock, 0);
 
     UTLT_Assert(parseArgs(argc, argv) == STATUS_OK, return STATUS_ERROR, 
                 "Error parsing args");
@@ -35,6 +36,7 @@ int main(int argc, char *argv[]) {
     UTLT_Assert(status == STATUS_OK, returnStatus = STATUS_ERROR,
                 "UPF terminate error");
 
+    pthread_mutex_destroy(&UTLT_logBufLock);
     return returnStatus;
 }
 


### PR DESCRIPTION
`UTLT_LogPrint()` is not thread safe. Therefore, the log message buffer is possible to be overwritten by another thread
while a thread is running `UTLT_LogPrint()`.

To make `UTLT_LogPrint()` thread safe, pthread mutex lock is used.