### PR TITLE
Suppress the frequency of sending PFCP Session Report Request messages

### DIFF
--- a/config/upfcfg.example.yaml
+++ b/config/upfcfg.example.yaml
@@ -9,6 +9,10 @@ configuration:
   debugLevel: info
   ReportCaller: false
 
+  # packetBufferHoldTime should be longer than Paging retry-out time of AMF.
+  # unit: seconds
+  packetBufferHoldTime: 30
+
   # The IP list of the N4 interface on this UPF (Can't set to 0.0.0.0)
   pfcp:
     - addr: 127.0.0.8

--- a/config/upfcfg.test.example.yaml
+++ b/config/upfcfg.test.example.yaml
@@ -9,6 +9,10 @@ configuration:
   debugLevel: info
   ReportCaller: false
 
+  # packetBufferHoldTime should be longer than Paging retry-out time of AMF.
+  # unit: seconds
+  packetBufferHoldTime: 30
+
   # The IP list of the N4 interface on this UPF (Can't set to 0.0.0.0)
   pfcp:
     - addr: 10.200.200.101

--- a/config/upfcfg.ulcl.example.yaml
+++ b/config/upfcfg.ulcl.example.yaml
@@ -9,6 +9,10 @@ configuration:
   debugLevel: info
   ReportCaller: false
 
+  # packetBufferHoldTime should be longer than Paging retry-out time of AMF.
+  # unit: seconds
+  packetBufferHoldTime: 30
+
   # The IP list of the N4 interface on this UPF (Can't set to 0.0.0.0)
   pfcp:
     - addr: 10.200.200.101

--- a/src/up/up_path.c
+++ b/src/up/up_path.c
@@ -197,7 +197,7 @@ Status UpSendPacketByPdrFar(UpfPDR *pdr, UpfFAR *far, Sock *sock) {
             UTLT_Assert(sendBuf, status = STATUS_ERROR; goto FREEBUFBLK, "create buffer error");
             Bufblk *pktBuf = bufStorage->packetBuffer;
             uint16_t pktlen;
-            for (void *pktDataPtr = pktBuf->buf; pktDataPtr < pktBuf->buf + pktBuf->len; pktDataPtr += pktlen) {
+            for (void *pktDataPtr = pktBuf->buf + sizeof(utime_t); pktDataPtr < pktBuf->buf + pktBuf->len; pktDataPtr += pktlen) {
                 pktlen = *(uint16_t *)pktDataPtr;
                 gtpHdr._length = htons(pktlen);
                 BufblkBytes(sendBuf, (void *)&gtpHdr, GTPV1_HEADER_LEN); // This must succeed

--- a/src/upf_config.c
+++ b/src/upf_config.c
@@ -223,6 +223,9 @@ Status UpfConfigParse() {
                             EnvParamsAddDNN(Self()->envParams, dnn);
                         }
                     } while (YamlIterType(&dnnList) == YAML_SEQUENCE_NODE);
+                } else if (!strcmp(upfKey, "packetBufferHoldTime")) {
+                    const char *holdTime = YamlIterGet(&upfIter, GET_VALUE);
+                    Self()->pktbufHoldTime = atoi(holdTime);
                 } else
                     UTLT_Warning("Unknown key \"%s\" of configuration", upfKey);
             }

--- a/src/upf_context.c
+++ b/src/upf_context.c
@@ -144,6 +144,7 @@ Status UpfContextInit() {
     strncpy(self.buffSockPath, "/tmp/free5gc_unix_sock", MAX_SOCK_PATH_LEN);
     self.sessionHash = HashMake();
     self.bufPacketHash = HashMake();
+    self.pktbufHoldTime = DEFAULT_PKTBUF_HOLDING_TIME;
     // spin lock protect write data instead of mutex protect code block
     int ret = pthread_spin_init(&self.buffLock, PTHREAD_PROCESS_PRIVATE);
     UTLT_Assert(ret == 0, , "buffLock cannot create: %s", strerror(ret));

--- a/src/upf_context.h
+++ b/src/upf_context.h
@@ -118,6 +118,8 @@ typedef struct {
     // Buffering socket for recv packet from kernel
     Sock            *buffSock;
 
+#define DEFAULT_PKTBUF_HOLDING_TIME 30
+    uint16_t        pktbufHoldTime;
 
     // Config file
     const char      *configFilePath;


### PR DESCRIPTION
- Put the timestamp field to the head of the packetBuffer
- Send PFCP Session Report Request message only when the packetBuffer is empty
  or when the timestamp stored at the head of the packetBuffer has been expired
- Update the timestamp in the packetBuffer when PFCP Session Report Request is sent
- Clear the packetBuffer if the timestamp has been expired when a new packet is going to be buffered

This PR is regarding with [Issue#290](https://github.com/free5gc/free5gc/issues/290).