### PR TITLE
refactor PacketInGTPUHandle (computed goto)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ add_custom_command(OUTPUT ${BUILD_CONFIG_DIR}
 )
 add_custom_target(configs ALL DEPENDS ${BUILD_CONFIG_DIR} VERBATIM)
 
-add_compile_options(-Wall -Werror -Wno-address-of-packed-member)
+add_compile_options(-Wall -Werror -Wno-address-of-packed-member -fno-gcse -fno-crossjumping)
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g3 -O0")
 
 # Submodules

--- a/src/up/up_match.h
+++ b/src/up/up_match.h
@@ -7,6 +7,14 @@
 #include "utlt_list.h"
 #include "updk/rule_pdr.h"
 
+#define UP_TYPE_NUM 256
+#define up_dispatcher(type) goto *up_dispatch_table[type]
+#define up_table_assign(type, label) up_dispatch_table[type] = &&label
+#define up_table_assign_all(range, label) for(int count = 0; count < range; count++){\
+            up_table_assign(count, label);\
+            isInitialized = 1;\
+        }
+
 typedef struct {
     ListHead node;
 


### PR DESCRIPTION
Considering to the bottleneck of UPF is user data packet processing, I think using `computed goto` to replace `switch-case` can bring more performance on branch prediction.
In the case of many users sending the data packet to UPF, `computed goto` can prevent the wrong branch prediction (it will cause the pipeline to be cleared).

## Reference
- [Computed goto for efficient dispatch tables](https://eli.thegreenplace.net/2012/07/12/computed-goto-for-efficient-dispatch-tables)