### PR TITLE
modify the modification req handler

### DIFF
--- a/lib/utlt/include/utlt_debug.h
+++ b/lib/utlt/include/utlt_debug.h
@@ -13,6 +13,8 @@ typedef int Status;
 #define STATUS_OK 0
 #define STATUS_EAGAIN 1
 
+#define NOOP (void) 0
+
 extern pthread_mutex_t UTLT_logBufLock;
 
 Status UTLT_SetLogLevel(const char *level);

--- a/src/n4/n4_dispatcher.c
+++ b/src/n4/n4_dispatcher.c
@@ -75,7 +75,7 @@ void UpfDispatcher(const Event *event) {
                 session = UpfSessionFindBySeid(pfcpMessage->header.seid);
             }
 
-            UTLT_Level_Assert(LOG_WARNING, session, goto freeBuf,
+            UTLT_Level_Assert(LOG_WARNING, session, NOOP,
                         "do not find / establish session");
 
             if (pfcpMessage->header.type != PFCP_SESSION_REPORT_RESPONSE) {

--- a/src/n4/n4_pfcp_build.h
+++ b/src/n4/n4_pfcp_build.h
@@ -18,7 +18,7 @@ Status UpfN4BuildSessionModificationResponse(
         PFCPSessionModificationRequest *modifyRequest);
 Status UpfN4BuildSessionDeletionResponse(
         Bufblk **bufBlkPtr, uint8_t type, UpfSession *session,
-        PFCPSessionDeletionRequest *deletionRequest);
+        PFCPSessionDeletionRequest *deletionRequest, bool sessionExisted);
 Status UpfN4BuildSessionReportRequestDownlinkDataReport (
         Bufblk **bufBlkPtr, uint8_t type, UpfSession *session, uint16_t pdrId);
 Status UpfN4BuildAssociationSetupResponse(

--- a/src/n4/n4_pfcp_handler.c
+++ b/src/n4/n4_pfcp_handler.c
@@ -1321,16 +1321,20 @@ Status UpfN4HandleSessionModificationRequest(UpfSession *session, PfcpXact *xact
 
 Status UpfN4HandleSessionDeletionRequest(UpfSession *session, PfcpXact *xact,
                                          PFCPSessionDeletionRequest *request) {
-    UTLT_Assert(session, return STATUS_ERROR, "session error");
     UTLT_Assert(xact, return STATUS_ERROR, "xact error");
 
     Status status;
     PfcpHeader header;
     Bufblk *bufBlk = NULL;
+    bool sessionExisted = (session)?(true):(false);
 
-    /* delete session */
-    UTLT_Assert(UpfSessionRemove(session) == STATUS_OK, return STATUS_ERROR,
-        "UpfSessionRemove failed");
+    if (sessionExisted) {
+        /* delete session */
+        UTLT_Assert(UpfSessionRemove(session) == STATUS_OK, return STATUS_ERROR,
+            "UpfSessionRemove failed");
+    } else {
+        UTLT_Warning("Session is not found");
+    }
 
     /* Send Session Deletion Response */
     memset(&header, 0, sizeof(PfcpHeader));
@@ -1339,7 +1343,7 @@ Status UpfN4HandleSessionDeletionRequest(UpfSession *session, PfcpXact *xact,
     header.seid = session->smfSeid;
 
     status = UpfN4BuildSessionDeletionResponse(&bufBlk, header.type,
-                                               session, request);
+                                               session, request, sessionExisted);
     UTLT_Assert(status == STATUS_OK, return STATUS_ERROR, "N4 build error");
 
     status = PfcpXactUpdateTx(xact, &header, bufBlk);

--- a/src/n4/n4_pfcp_handler.c
+++ b/src/n4/n4_pfcp_handler.c
@@ -1188,109 +1188,112 @@ Status UpfN4HandleSessionEstablishmentRequest(UpfSession *session, PfcpXact *pfc
 
 Status UpfN4HandleSessionModificationRequest(UpfSession *session, PfcpXact *xact,
                                              PFCPSessionModificationRequest *request) {
-    UTLT_Assert(session, return STATUS_ERROR, "Session error");
     UTLT_Assert(xact, return STATUS_ERROR, "xact error");
 
     Status status;
     PfcpHeader header;
     Bufblk *bufBlk;
 
-    /* Create FAR */
-    for (int i = 0; i < sizeof(request->createFAR) / sizeof(CreateFAR); i++) {
-        if (request->createFAR[i].presence) {
-            status = UpfN4HandleCreateFar(session, &request->createFAR[i]);
-            UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
-                        "Modification: Create FAR error");
+    if (!session) {
+        UTLT_Warning("Session is not found");
+    } else {
+        /* Create FAR */
+        for (int i = 0; i < sizeof(request->createFAR) / sizeof(CreateFAR); i++) {
+            if (request->createFAR[i].presence) {
+                status = UpfN4HandleCreateFar(session, &request->createFAR[i]);
+                UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
+                            "Modification: Create FAR error");
+            }
         }
-    }
 
-    /* Create QER */
-    for (int i = 0; i < sizeof(request->createQER) / sizeof(CreateQER); i++) {
-        if (request->createQER[i].presence) {
-            status = UpfN4HandleCreateQer(session, &request->createQER[i]);
-            UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
-                        "Modification: Create QER error");
+        /* Create QER */
+        for (int i = 0; i < sizeof(request->createQER) / sizeof(CreateQER); i++) {
+            if (request->createQER[i].presence) {
+                status = UpfN4HandleCreateQer(session, &request->createQER[i]);
+                UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
+                            "Modification: Create QER error");
+            }
         }
-    }
 
-    // The order of PDF should be the lastest
-    /* Create PDR */
-    for (int i = 0; i < sizeof(request->createPDR) / sizeof(CreatePDR); i++) {
-        if (request->createPDR[i].presence) {
-            status = UpfN4HandleCreatePdr(session, &request->createPDR[i]);
-            UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
-                        "Modification: Create PDR error");
+        // The order of PDF should be the lastest
+        /* Create PDR */
+        for (int i = 0; i < sizeof(request->createPDR) / sizeof(CreatePDR); i++) {
+            if (request->createPDR[i].presence) {
+                status = UpfN4HandleCreatePdr(session, &request->createPDR[i]);
+                UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
+                            "Modification: Create PDR error");
+            }
         }
-    }
 
-    /* Update FAR */
-    for (int i = 0; i < sizeof(request->updateFAR) / sizeof(UpdateFAR); i++) {
-        if (request->updateFAR[i].presence) {
-            UTLT_Assert(request->updateFAR[i].fARID.presence == 1, ,
-                        "[PFCP] FarId in updateFAR not presence");
-            status = UpfN4HandleUpdateFar(session, &request->updateFAR[i]);
-            UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
-                        "Modification: Update FAR error");
+        /* Update FAR */
+        for (int i = 0; i < sizeof(request->updateFAR) / sizeof(UpdateFAR); i++) {
+            if (request->updateFAR[i].presence) {
+                UTLT_Assert(request->updateFAR[i].fARID.presence == 1, ,
+                            "[PFCP] FarId in updateFAR not presence");
+                status = UpfN4HandleUpdateFar(session, &request->updateFAR[i]);
+                UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
+                            "Modification: Update FAR error");
+            }
         }
-    }
 
-    /* Update QER */
-    for (int i = 0; i < sizeof(request->updateQER) / sizeof(UpdateQER); i++) {
-        if (request->updateQER[i].presence) {
-            UTLT_Assert(request->updateQER[i].qERID.presence == 1, ,
-                        "[PFCP] QerId in updateQER not presence");
-            status = UpfN4HandleUpdateQer(session, &request->updateQER[i]);
-            UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
-                        "Modification: Update QER error");
+        /* Update QER */
+        for (int i = 0; i < sizeof(request->updateQER) / sizeof(UpdateQER); i++) {
+            if (request->updateQER[i].presence) {
+                UTLT_Assert(request->updateQER[i].qERID.presence == 1, ,
+                            "[PFCP] QerId in updateQER not presence");
+                status = UpfN4HandleUpdateQer(session, &request->updateQER[i]);
+                UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
+                            "Modification: Update QER error");
+            }
         }
-    }
 
-    // The order of PDF should be the lastest
-    /* Update PDR */
-    for (int i = 0; i < sizeof(request->updatePDR) / sizeof(UpdatePDR); i++) {
-        if (request->updatePDR[i].presence) {
-            UTLT_Assert(request->updatePDR[i].pDRID.presence == 1, ,
-                        "[PFCP] PdrId in updatePDR not presence!");
-            status = UpfN4HandleUpdatePdr(session, &request->updatePDR[i]);
-            UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
-                        "Modification: Update PDR error");
+        // The order of PDF should be the lastest
+        /* Update PDR */
+        for (int i = 0; i < sizeof(request->updatePDR) / sizeof(UpdatePDR); i++) {
+            if (request->updatePDR[i].presence) {
+                UTLT_Assert(request->updatePDR[i].pDRID.presence == 1, ,
+                            "[PFCP] PdrId in updatePDR not presence!");
+                status = UpfN4HandleUpdatePdr(session, &request->updatePDR[i]);
+                UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
+                            "Modification: Update PDR error");
+            }
         }
-    }
 
-    /* Remove FAR */
-    for (int i = 0; i < sizeof(request->removeFAR) / sizeof(RemoveFAR); i++) {
-        if (request->removeFAR[i].presence) {
-            UTLT_Assert(request->removeFAR[i].fARID.presence == 1, ,
-                        "[PFCP] FarId in removeFAR not presence");
-            status = UpfN4HandleRemoveFar(session, *(uint32_t*)
-                                        request->removeFAR[i].fARID.value);
-            UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
-                        "Modification: Remove FAR error");
+        /* Remove FAR */
+        for (int i = 0; i < sizeof(request->removeFAR) / sizeof(RemoveFAR); i++) {
+            if (request->removeFAR[i].presence) {
+                UTLT_Assert(request->removeFAR[i].fARID.presence == 1, ,
+                            "[PFCP] FarId in removeFAR not presence");
+                status = UpfN4HandleRemoveFar(session, *(uint32_t*)
+                                            request->removeFAR[i].fARID.value);
+                UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
+                            "Modification: Remove FAR error");
+            }
         }
-    }
 
-    /* Remove QER */
-    for (int i = 0; i < sizeof(request->removeQER) / sizeof(RemoveQER); i++) {
-        if (request->removeQER[i].presence) {
-            UTLT_Assert(request->removeQER[i].qERID.presence == 1, ,
-                        "[PFCP] QerId in removeQER not presence");
-            status = UpfN4HandleRemoveQer(session, *(uint32_t*)
-                                        request->removeQER[i].qERID.value);
-            UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
-                        "Modification: Remove QER error");
+        /* Remove QER */
+        for (int i = 0; i < sizeof(request->removeQER) / sizeof(RemoveQER); i++) {
+            if (request->removeQER[i].presence) {
+                UTLT_Assert(request->removeQER[i].qERID.presence == 1, ,
+                            "[PFCP] QerId in removeQER not presence");
+                status = UpfN4HandleRemoveQer(session, *(uint32_t*)
+                                            request->removeQER[i].qERID.value);
+                UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
+                            "Modification: Remove QER error");
+            }
         }
-    }
 
-    // The order of PDF should be the lastest
-    /* Remove PDR */
-    for (int i = 0; i < sizeof(request->removePDR) / sizeof(RemovePDR); i++) {
-        if (request->removePDR[i].presence) {
-            UTLT_Assert(request->removePDR[i].pDRID.presence == 1, ,
-                        "[PFCP] PdrId in removePDR not presence!");
-            status = UpfN4HandleRemovePdr(session, *(uint16_t*)
-                                        request->removePDR[i].pDRID.value);
-            UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
-                        "Modification: Remove PDR error");
+        // The order of PDF should be the lastest
+        /* Remove PDR */
+        for (int i = 0; i < sizeof(request->removePDR) / sizeof(RemovePDR); i++) {
+            if (request->removePDR[i].presence) {
+                UTLT_Assert(request->removePDR[i].pDRID.presence == 1, ,
+                            "[PFCP] PdrId in removePDR not presence!");
+                status = UpfN4HandleRemovePdr(session, *(uint16_t*)
+                                            request->removePDR[i].pDRID.value);
+                UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
+                            "Modification: Remove PDR error");
+            }
         }
     }
 


### PR DESCRIPTION
[UPF PR #47 ](https://github.com/free5gc/upf/pull/47)

According to TS 29.244:
- 6.3.3 PFCP Session Modification Procedure
![](https://i.imgur.com/d6woupC.png)
- 7.2.2.4.2 Conditions for Sending SEID=0 in PFCP Header
![](https://i.imgur.com/g1I15TP.png)

Even if the session hasn't been found when processing the N4 modification request, UPF should send the N4 modification 
response with cause `PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND` and SEID = 0 to SMF still.
