### PR TITLE
add UpfSendNoSessionRsp()

### DIFF
--- a/src/n4/n4_dispatcher.c
+++ b/src/n4/n4_dispatcher.c
@@ -75,11 +75,13 @@ void UpfDispatcher(const Event *event) {
                 session = UpfSessionFindBySeid(pfcpMessage->header.seid);
             }
 
-            UTLT_Level_Assert(LOG_WARNING, session, goto freeBuf,
+            UTLT_Level_Assert(LOG_WARNING, session, UpfSendNoSessionRsp(pfcpMessage, upf),
                         "do not find / establish session");
 
-            if (pfcpMessage->header.type != PFCP_SESSION_REPORT_RESPONSE) {
+            if (pfcpMessage->header.type != PFCP_SESSION_REPORT_RESPONSE && session) {
                 session->pfcpNode = upf;
+            } else {
+                goto freeBuf;
             }
 
             status = PfcpXactReceive(session->pfcpNode,

--- a/src/n4/n4_pfcp_build.c
+++ b/src/n4/n4_pfcp_build.c
@@ -75,15 +75,17 @@ Status UpfN4BuildSessionModificationResponse(Bufblk **bufBlkPtr, uint8_t type,
 
     /* cause */
     response->cause.presence = 1;
-    cause = PFCP_CAUSE_REQUEST_ACCEPTED;
+    if (session) {
+        cause = PFCP_CAUSE_REQUEST_ACCEPTED;
+    } else {
+        cause = PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND;
+    }
     response->cause.value = &cause;
-    response->cause.len = 1;
+    response->cause.len = sizeof(cause);
 
     /* TODO: Set Offending IE, Create PDR, Load Control Information, Overload Control Information, Usage Report, Failed Rule ID, Additional Usage Reports Information, Created/Updated Traffic Endpoint */
 
     pfcpMessage.header.type = type;
-    pfcpMessage.header.seidP = 1;
-    pfcpMessage.header.seid = session->smfSeid;
     status = PfcpBuildMessage(bufBlkPtr, &pfcpMessage);
     UTLT_Assert(status == STATUS_OK, return STATUS_ERROR, "PFCP build error");
 
@@ -104,9 +106,13 @@ Status UpfN4BuildSessionDeletionResponse(Bufblk **bufBlkPtr, uint8_t type,
 
     /* cause */
     response->cause.presence = 1;
-    cause = PFCP_CAUSE_REQUEST_ACCEPTED;
+    if (session) {
+        cause = PFCP_CAUSE_REQUEST_ACCEPTED;
+    } else {
+        cause = PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND;
+    }
     response->cause.value = &cause;
-    response->cause.len = 1;
+    response->cause.len = sizeof(cause);
 
     /* TODO: Set Offending IE, Load Control Information, Overload Control Information, Usage Report */
 

--- a/src/n4/n4_pfcp_handler.c
+++ b/src/n4/n4_pfcp_handler.c
@@ -9,6 +9,7 @@
 
 #include "upf_context.h"
 #include "pfcp_message.h"
+#include "pfcp_path.h"
 #include "pfcp_xact.h"
 #include "pfcp_convert.h"
 #include "n4_pfcp_build.h"
@@ -1313,6 +1314,55 @@ Status UpfN4HandleSessionModificationRequest(UpfSession *session, PfcpXact *xact
                 "PFCP Commit error");
 
     UTLT_Info("[PFCP] Session Modification Response");
+    return STATUS_OK;
+}
+
+Status UpfSendNoSessionRsp(PfcpMessage *pfcpMessage, PfcpNode *node){
+    Status status;
+    Bufblk *bufBlk;
+    uint8_t type;
+    uint32_t sqn = pfcpMessage->header.sqn;
+
+    switch (pfcpMessage->header.type) {
+        case PFCP_SESSION_MODIFICATION_REQUEST:
+            UTLT_Info("[PFCP] Handle PFCP session modification request");
+            type = PFCP_SESSION_MODIFICATION_RESPONSE;
+            status = UpfN4BuildSessionModificationResponse(&bufBlk, type, NULL, &pfcpMessage->pFCPSessionModificationRequest);
+            UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
+                "N4 build error");
+            break;
+        case PFCP_SESSION_DELETION_REQUEST:
+            UTLT_Info("[PFCP] Handle PFCP session deletion request");
+            type = PFCP_SESSION_DELETION_RESPONSE;
+            status = UpfN4BuildSessionDeletionResponse(&bufBlk, type, NULL, &pfcpMessage->pFCPSessionDeletionRequest);
+            UTLT_Assert(status == STATUS_OK, return STATUS_ERROR,
+                 "N4 build error");
+            break;
+        default:
+            UTLT_Error("No implement pfcp type: %d", pfcpMessage->header.type);
+            return STATUS_ERROR;
+        }
+
+    PfcpHeader *localHeader = NULL;
+    Bufblk *fullPacket = BufblkAlloc(1, PFCP_HEADER_LEN);
+    UTLT_Assert(fullPacket, return STATUS_ERROR, "buffer block alloc error");
+    localHeader = fullPacket->buf;
+    fullPacket->len = PFCP_HEADER_LEN;
+    memset(localHeader, 0, PFCP_HEADER_LEN);
+    localHeader->version = PFCP_VERSION;
+    localHeader->type = type;
+    localHeader->seidP = 1;
+    localHeader->seid = 0;
+    localHeader->sqn = sqn;
+
+    localHeader->length = htons(bufBlk->len + PFCP_HEADER_LEN - 4);
+
+    UTLT_Assert(BufblkBuf(fullPacket, bufBlk) == STATUS_OK, BufblkFree(fullPacket); return STATUS_ERROR, "buffer block buffering error");
+    status = PfcpSend(node, fullPacket);
+    BufblkFree(bufBlk);
+    BufblkFree(fullPacket);
+    UTLT_Assert(status == STATUS_OK, return STATUS_ERROR, "PfcpSend error");
+
     return STATUS_OK;
 }
 

--- a/src/n4/n4_pfcp_handler.h
+++ b/src/n4/n4_pfcp_handler.h
@@ -30,6 +30,7 @@ void UpfN4HandleAssociationUpdateRequest(PfcpXact *xact, PFCPAssociationUpdateRe
 void UpfN4HandleAssociationReleaseRequest(PfcpXact *xact, PFCPAssociationReleaseRequest *request);
 void UpfN4HandleHeartbeatRequest(PfcpXact *xact, HeartbeatRequest *request);
 void UpfN4HandleHeartbeatResponse(PfcpXact *xact, HeartbeatResponse *response);
+void UpfSendNoSessionRsp(PfcpMessage *pfcpMessage, PfcpNode *node);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
[UPF PR #47 ](https://github.com/free5gc/upf/pull/47)

According to TS 29.244:
- 6.3.3 PFCP Session Modification Procedure
![](https://i.imgur.com/d6woupC.png)
- 7.2.2.4.2 Conditions for Sending SEID=0 in PFCP Header
![](https://i.imgur.com/g1I15TP.png)

Even if the session hasn't been found when processing the N4 modification request/deletion request, UPF should send the N4 response with cause `PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND` and SEID = 0 to SMF still.
